### PR TITLE
Better Fetching, Blind Components, Single Instance Route

### DIFF
--- a/src/components/presets/modals/AddInstanceModal.vue
+++ b/src/components/presets/modals/AddInstanceModal.vue
@@ -25,7 +25,13 @@ const submit = () => {
 		store.instances.push(input);
 
 		// queue instance api fetch
-		store.fetchAllInstanceEndpointData(store.instances.length - 1);
+		store
+			.fetchAllInstanceEndpointData(input)
+			.then(
+				(response: IInstanceData | undefined | null) =>
+					(store.instanceData[store.instances.length - 1] =
+						response as IInstanceData)
+			);
 	}
 };
 </script>

--- a/src/components/presets/panel/InstancePanel.vue
+++ b/src/components/presets/panel/InstancePanel.vue
@@ -2,66 +2,57 @@
 // utility functions
 import { dataExists } from "~/utility";
 
-// get state
-import useStore from "~/stores";
-const store = useStore();
-
 // props
 const props = defineProps<{
-	instanceID: number;
+	instanceData: IInstanceData;
 	panelStyle: string[];
 }>();
+
+//FIXME: what the hell is going on here? first var returns with properties fully propagated, but the second is empty- but only on first load?
+// console.log(props.instanceData, (props.instanceData).trainer, dataExists(props.instanceData.trainer))
 </script>
 
 <template>
 	<!-- Sidebar -->
-	<Sidebar :panel-style="panelStyle[0]" />
+	<Sidebar :panel-style="props.panelStyle[0]" />
 
 	<!-- Trainer Info -->
 	<LoadingCard
-		:panel-style="panelStyle[1]"
-		v-if="!dataExists(store.instanceData[instanceID].trainer)"
+		:panel-style="props.panelStyle[1]"
+		v-if="!dataExists(props.instanceData.trainer)"
 	/>
 	<TrainerCard
 		v-else
-		:panel-style="panelStyle[1]"
-		:data="store.instanceData[instanceID].trainer"
+		:panel-style="props.panelStyle[1]"
+		:data="props.instanceData.trainer"
 	/>
 
 	<!-- Team Info -->
 	<LoadingCard
-		:panel-style="panelStyle[2]"
-		v-if="!dataExists(store.instanceData[instanceID].party)"
+		:panel-style="props.panelStyle[2]"
+		v-if="!dataExists(props.instanceData.party)"
 	/>
-	<PartyCard
-		v-else
-		:panel-style="panelStyle[2]"
-		:data="store.instanceData[instanceID].party"
-	/>
+	<PartyCard v-else :panel-style="panelStyle[2]" :data="props.instanceData.party" />
 
 	<!-- Encounter Info -->
 	<LoadingCard
-		:panel-style="panelStyle[3]"
+		:panel-style="props.panelStyle[3]"
 		v-if="
-			!dataExists(store.instanceData[instanceID].encounter_log) ||
-			!dataExists(store.instanceData[instanceID].shiny_log)
+			!dataExists(props.instanceData.encounter_log) ||
+			!dataExists(props.instanceData.shiny_log)
 		"
 	/>
 	<EncountersCard
 		v-else
-		:panel-style="panelStyle[3]"
-		:encounter-log-data="store.instanceData[instanceID].encounter_log"
-		:shiny-log-data="store.instanceData[instanceID].shiny_log"
+		:panel-style="props.panelStyle[3]"
+		:encounter-log-data="props.instanceData.encounter_log"
+		:shiny-log-data="props.instanceData.shiny_log"
 	/>
 
 	<!-- Stats -->
 	<LoadingCard
-		:panel-style="panelStyle[4]"
-		v-if="!dataExists(store.instanceData[instanceID].stats)"
+		:panel-style="props.panelStyle[4]"
+		v-if="!dataExists(props.instanceData.stats)"
 	/>
-	<StatsCard
-		v-else
-		:panel-style="panelStyle[4]"
-		:data="store.instanceData[instanceID].stats"
-	/>
+	<StatsCard v-else :panel-style="props.panelStyle[4]" :data="props.instanceData.stats" />
 </template>

--- a/src/components/presets/panel/InstancePanel.vue
+++ b/src/components/presets/panel/InstancePanel.vue
@@ -7,9 +7,6 @@ const props = defineProps<{
 	instanceData: IInstanceData;
 	panelStyle: string[];
 }>();
-
-//FIXME: what the hell is going on here? first var returns with properties fully propagated, but the second is empty- but only on first load?
-// console.log(props.instanceData, (props.instanceData).trainer, dataExists(props.instanceData.trainer))
 </script>
 
 <template>
@@ -19,7 +16,7 @@ const props = defineProps<{
 	<!-- Trainer Info -->
 	<LoadingCard
 		:panel-style="props.panelStyle[1]"
-		v-if="!dataExists(props.instanceData.trainer)"
+		v-if="!props.instanceData || !dataExists(props.instanceData.trainer)"
 	/>
 	<TrainerCard
 		v-else
@@ -30,14 +27,19 @@ const props = defineProps<{
 	<!-- Team Info -->
 	<LoadingCard
 		:panel-style="props.panelStyle[2]"
-		v-if="!dataExists(props.instanceData.party)"
+		v-if="!props.instanceData || !dataExists(props.instanceData.party)"
 	/>
-	<PartyCard v-else :panel-style="panelStyle[2]" :data="props.instanceData.party" />
+	<PartyCard
+		v-else
+		:panel-style="panelStyle[2]"
+		:data="props.instanceData.party"
+	/>
 
 	<!-- Encounter Info -->
 	<LoadingCard
 		:panel-style="props.panelStyle[3]"
 		v-if="
+			!props.instanceData ||
 			!dataExists(props.instanceData.encounter_log) ||
 			!dataExists(props.instanceData.shiny_log)
 		"
@@ -52,7 +54,11 @@ const props = defineProps<{
 	<!-- Stats -->
 	<LoadingCard
 		:panel-style="props.panelStyle[4]"
-		v-if="!dataExists(props.instanceData.stats)"
+		v-if="!props.instanceData || !dataExists(props.instanceData.stats)"
 	/>
-	<StatsCard v-else :panel-style="props.panelStyle[4]" :data="props.instanceData.stats" />
+	<StatsCard
+		v-else
+		:panel-style="props.panelStyle[4]"
+		:data="props.instanceData.stats"
+	/>
 </template>

--- a/src/components/views/InstancePanels.vue
+++ b/src/components/views/InstancePanels.vue
@@ -1,7 +1,13 @@
 <script setup lang="ts">
-// get state
-import useStore from "~/stores";
-const store = useStore();
+// props
+const props = withDefaults(
+	defineProps<{
+		instances: Ref<string[]> | Ref<string>;
+		instanceData: Ref<IInstanceData[]> | Ref<IInstanceData>;
+		allowInstanceManipulation?: boolean;
+	}>(),
+	{ allowInstanceManipulation: true }
+);
 
 // individual panel style
 const panelStyleBase =
@@ -22,16 +28,19 @@ const modalAddInstanceOpen = ref(false);
 	<!-- Buttons -->
 	<div class="flex flex-col m-4 absolute top-0 right-0">
 		<ThemeButton />
-		<div class="mb-2"></div>
-		<IconButton
-			@clickEvent="() => (modalAddInstanceOpen = true)"
-			icon="i-material-symbols-add-box-rounded"
-		/>
+		<span v-if="props.allowInstanceManipulation">
+			<div class="mb-2"></div>
+			<IconButton
+				@clickEvent="() => (modalAddInstanceOpen = true)"
+				icon="i-material-symbols-add-box-rounded"
+			/>
+		</span>
 	</div>
 
 	<!-- Content -->
 	<div class="mt-5 w-[90%] flex justify-center">
 		<ul class="overflow-auto my-3 w-full scrollbar-hidden">
+			<!-- Titles -->
 			<li class="flex justify-center mb-3">
 				<!-- Sidebar Spacing -->
 				<div
@@ -61,11 +70,25 @@ const modalAddInstanceOpen = ref(false);
 					<h1 class="font-bold">Stats</h1>
 				</div>
 			</li>
+
+			<!-- Multiple Instances -->
 			<li
-				v-for="(_apiURL, index) in store.instances"
+				v-if="props.instances.value instanceof Array"
+				v-for="(_apiURL, index) in props.instances.value"
 				class="flex justify-center mb-3"
 			>
-				<InstancePanel :panelStyle="panelStyle" :instanceID="index" />
+				<InstancePanel
+					:panelStyle="panelStyle"
+					:instanceData="(props.instanceData as Ref<IInstanceData[]>).value[index]"
+				/>
+			</li>
+
+			<!-- Single Instance -->
+			<li v-else class="flex justify-center mb-3">
+				<InstancePanel
+					:panelStyle="panelStyle"
+					:instanceData="(props.instanceData as Ref<IInstanceData>).value"
+				/>
 			</li>
 		</ul>
 

--- a/src/components/views/InstancePanels.vue
+++ b/src/components/views/InstancePanels.vue
@@ -2,8 +2,8 @@
 // props
 const props = withDefaults(
 	defineProps<{
-		instances: Ref<string[]> | Ref<string>;
-		instanceData: Ref<IInstanceData[]> | Ref<IInstanceData>;
+		instances: string[] | string;
+		instanceData: IInstanceData[] | IInstanceData;
 		allowInstanceManipulation?: boolean;
 	}>(),
 	{ allowInstanceManipulation: true }
@@ -73,13 +73,13 @@ const modalAddInstanceOpen = ref(false);
 
 			<!-- Multiple Instances -->
 			<li
-				v-if="props.instances.value instanceof Array"
-				v-for="(_apiURL, index) in props.instances.value"
+				v-if="props.instances instanceof Array"
+				v-for="(_apiURL, index) in props.instances"
 				class="flex justify-center mb-3"
 			>
 				<InstancePanel
 					:panelStyle="panelStyle"
-					:instanceData="(props.instanceData as Ref<IInstanceData[]>).value[index]"
+					:instanceData="(props.instanceData as IInstanceData[])[index]"
 				/>
 			</li>
 
@@ -87,7 +87,7 @@ const modalAddInstanceOpen = ref(false);
 			<li v-else class="flex justify-center mb-3">
 				<InstancePanel
 					:panelStyle="panelStyle"
-					:instanceData="(props.instanceData as Ref<IInstanceData>).value"
+					:instanceData="(props.instanceData as IInstanceData)"
 				/>
 			</li>
 		</ul>

--- a/src/pages/index.vue
+++ b/src/pages/index.vue
@@ -6,9 +6,6 @@ import type { ShallowRef } from "vue";
 import Loading from "~/components/views/Loading.vue";
 import InstancePanels from "~/components/views/InstancePanels.vue";
 
-// utility functions
-// import { dataExists } from "~/utility";
-
 // get state
 import useStore from "~/stores";
 const store = useStore();
@@ -18,18 +15,18 @@ const activeView: ShallowRef<Component> = shallowRef(Loading);
 
 onMounted(async () => {
 	// no longer loading
-	// activeView.value = InstancePanels;
+	activeView.value = InstancePanels;
+});
 
-	// update instance data for all stored instances
-	store.instances.forEach(async (_data, index) => {
-		// update instance data (force to keep fetching if no response)
-		await store
-			.fetchAllInstanceEndpointData(store.instances[index], true)
-			.then((response: IInstanceData) => {
-				console.log(response)
-				store.instanceData[index] = response;
-			});
-	});
+// update instance data for all stored instances
+store.instances.forEach(async (_data, index) => {
+	// fetch all endpoints from each instance's api
+	await store
+		.fetchAllInstanceEndpointData(store.instances[index])
+		.then((response: IInstanceData) => {
+			// save response for this endpoint on this instance
+			store.instanceData[index] = response;
+		});
 });
 
 // determine props needed for active view

--- a/src/pages/index.vue
+++ b/src/pages/index.vue
@@ -1,9 +1,13 @@
 <script setup lang="ts">
+// vue
 import type { ShallowRef } from "vue";
 
 // views
 import Loading from "~/components/views/Loading.vue";
 import InstancePanels from "~/components/views/InstancePanels.vue";
+
+// utility functions
+// import { dataExists } from "~/utility";
 
 // get state
 import useStore from "~/stores";
@@ -14,19 +18,35 @@ const activeView: ShallowRef<Component> = shallowRef(Loading);
 
 onMounted(async () => {
 	// no longer loading
-	activeView.value = InstancePanels;
+	// activeView.value = InstancePanels;
 
 	// update instance data for all stored instances
 	store.instances.forEach(async (_data, index) => {
 		// update instance data (force to keep fetching if no response)
-		store.fetchAllInstanceEndpointData(index, true);
+		await store
+			.fetchAllInstanceEndpointData(store.instances[index], true)
+			.then((response: IInstanceData) => {
+				console.log(response)
+				store.instanceData[index] = response;
+			});
 	});
+});
+
+// determine props needed for active view
+const activeProps = computed(() => {
+	if (activeView.value == InstancePanels) {
+		return {
+			instances: store.instances,
+			instanceData: store.instanceData,
+			allowInstanceManipulation: false,
+		};
+	}
 });
 </script>
 
 <template>
 	<div class="h-screen overflow-hidden flex justify-center">
 		<!-- View -->
-		<component :is="activeView" />
+		<component :is="activeView" v-bind="activeProps" />
 	</div>
 </template>

--- a/src/pages/instance.vue
+++ b/src/pages/instance.vue
@@ -1,0 +1,60 @@
+<script setup lang="ts">
+// vue
+import type { ShallowRef } from "vue";
+
+// views
+import Loading from "~/components/views/Loading.vue";
+import InstancePanels from "~/components/views/InstancePanels.vue";
+
+// utility functions
+import { dataExists } from "~/utility";
+
+// get state
+import useStore from "~/stores";
+const store = useStore();
+
+// initial active view
+const activeView: ShallowRef<Component> = shallowRef(Loading);
+
+// instance api URL
+const apiURL: Ref<string> | Ref<string[]> | Ref<undefined> = ref();
+
+// instance data
+const instanceData: Ref<IInstanceData> | Ref<IInstanceData[]> | Ref<undefined> = ref();
+
+onMounted(() => {
+	// update instance api url input
+	apiURL.value = String(useRoute().query.api);
+
+	// fetch instance data (force to keep fetching if no response)
+	store
+		.fetchAllInstanceEndpointData(apiURL.value, true)
+		.then((response: IInstanceData) => {
+			// update instance data
+			if (dataExists(response)) instanceData.value = response;
+
+			// change to instance panels view
+			activeView.value = InstancePanels;
+		});
+});
+
+// determine props needed for active view
+const activeProps = computed(() => {
+	if (activeView.value == InstancePanels) {
+		return {
+			instances: apiURL as Ref<string> | Ref<string[]>,
+			instanceData: instanceData as
+				| Ref<IInstanceData>
+				| Ref<IInstanceData[]>,
+			allowInstanceManipulation: false,
+		};
+	}
+});
+</script>
+
+<template>
+	<div class="h-screen overflow-hidden flex justify-center">
+		<!-- View -->
+		<component :is="activeView" v-bind="activeProps" />
+	</div>
+</template>

--- a/src/pages/instance.vue
+++ b/src/pages/instance.vue
@@ -6,9 +6,6 @@ import type { ShallowRef } from "vue";
 import Loading from "~/components/views/Loading.vue";
 import InstancePanels from "~/components/views/InstancePanels.vue";
 
-// utility functions
-import { dataExists } from "~/utility";
-
 // get state
 import useStore from "~/stores";
 const store = useStore();
@@ -16,36 +13,35 @@ const store = useStore();
 // initial active view
 const activeView: ShallowRef<Component> = shallowRef(Loading);
 
+onMounted(async () => {
+	// no longer loading
+	activeView.value = InstancePanels;
+});
+
 // instance api URL
-const apiURL: Ref<string> | Ref<string[]> | Ref<undefined> = ref();
+const apiURL: Ref<string> | Ref<undefined> = ref();
 
 // instance data
-const instanceData: Ref<IInstanceData> | Ref<IInstanceData[]> | Ref<undefined> = ref();
+const instanceData: Ref<IInstanceData> | Ref<undefined> = ref();
 
-onMounted(() => {
-	// update instance api url input
-	apiURL.value = String(useRoute().query.api);
+// update instance api url input
+apiURL.value = String(useRoute().query.api);
 
-	// fetch instance data (force to keep fetching if no response)
-	store
-		.fetchAllInstanceEndpointData(apiURL.value, true)
-		.then((response: IInstanceData) => {
-			// update instance data
-			if (dataExists(response)) instanceData.value = response;
-
-			// change to instance panels view
-			activeView.value = InstancePanels;
-		});
-});
+// FIXME: Causing "A composable that requires access to the Nuxt instance was called outside of a plugin, Nuxt hook, Nuxt middleware, or Vue setup function. This is probably not a Nuxt bug. Find out more at `https://nuxt.com/docs/guide/concepts/auto-imports#using-vue-and-nuxt-composables`." error... but still works?
+// fetch all endpoints from the provided instance's api url
+store
+	.fetchAllInstanceEndpointData(apiURL.value as string)
+	.then((response: IInstanceData) => {
+		// save response for this endpoint
+		instanceData.value = response;
+	});
 
 // determine props needed for active view
 const activeProps = computed(() => {
 	if (activeView.value == InstancePanels) {
 		return {
-			instances: apiURL as Ref<string> | Ref<string[]>,
-			instanceData: instanceData as
-				| Ref<IInstanceData>
-				| Ref<IInstanceData[]>,
+			instances: apiURL.value,
+			instanceData: instanceData.value,
 			allowInstanceManipulation: false,
 		};
 	}

--- a/src/types/global.d.ts
+++ b/src/types/global.d.ts
@@ -2,12 +2,22 @@
 interface IInstanceData {
 	trainer: ITrainer;
 	items: IItems;
-	party: IPokemon[];
+	party: TParty;
 	encounter_log: TEncounterLog;
 	shiny_log: TShinyLog;
 	encounter_rate: TEncounterRate;
 	stats: IStats;
 }
+
+/** Possible Endpoint Data */
+type InstanceData =
+| ITrainer
+| IItems
+| TParty
+| TEncounterLog
+| TShinyLog
+| TEncounterRate
+| IStats;
 
 /** Possible Endpoints */
 type InstanceDataKey =

--- a/src/utility.ts
+++ b/src/utility.ts
@@ -7,7 +7,7 @@ export const pkmnRefRaw = (natID: number, isShiny: boolean) => {
 };
 
 export const dataExists = (data: unknown) => {
-	if (JSON.stringify(data) === "{}" || data == null) {
+	if (JSON.stringify(data) === "{}" || data === null || data === undefined) {
 		return false;
 	}
 	return true;


### PR DESCRIPTION
- Added a new route `example.dashboard.com/instance?api=<API URL>`, which only shows a single instance.
- Removed "force" in API fetching. Fetching is required to be synchronous, and will throw an error if fails. 
- Removed components' reliance on `store`. They will now be passed the relevant data from the top level route.
- Added an option to InstancePanels component that removes the ability to manipulate the panels for end users. Particularly useful when there's only one panel meant to be shown.